### PR TITLE
remove main-center class on loader hide

### DIFF
--- a/load-data.js
+++ b/load-data.js
@@ -30,6 +30,7 @@ export function showLoadingIcon(element) {
 }
 
 export function hideLoadingIcon(element) {
+  d3.select(element).classed("main-center", false);
   style?.remove();
   d3.select(element).select("#metastanza-loading-icon-div").remove();
 }


### PR DESCRIPTION
hideLoadingIcon の時に　`main-center`　CSSクラスを外す